### PR TITLE
add copy dist files to root script

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "docs:dev": "vuepress dev docs",
-    "docs:build": "vuepress build docs"
+    "docs:build": "vuepress build docs && cp -rf ./docs/.vuepress/dist/* ../"
   },
   "dependencies": {
     "bootstrap": "^4.3.1",


### PR DESCRIPTION
매번 npm run docs:build 하고 나서 결과물인 dist 를 root 로 복사해야 하는데 
이부분을 npm script에 추가해서 빌드후에 같이 실행되도록 추가했습니다.

